### PR TITLE
Make toolbar logo link to sbw-media.ch

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@ input[type=text]:focus, input[type=number]:focus, select:focus { border-color: #
   <button class="btn btn-secondary" onclick="saveJSON()">&#128190; Save</button>
   <button class="btn btn-secondary" onclick="loadJSON()">&#128194; Load</button>
   <span class="hint">E = new entity &nbsp;|&nbsp; R = relationship tool &nbsp;|&nbsp; ESC = cancel</span>
-  <img src="assets/sbw-neue-medien.svg" alt="SBW Neue Medien" style="height:32px;margin-left:auto;opacity:0.85;">
+  <a href="https://sbw-media.ch" target="_blank" rel="noopener" style="margin-left:auto;display:flex;align-items:center;"><img src="assets/sbw-neue-medien.svg" alt="SBW Neue Medien" style="height:32px;opacity:0.85;"></a>
 </div>
 
 <div id="canvas-wrapper">


### PR DESCRIPTION
## Summary

- Wraps the SBW Neue Medien logo in an anchor tag linking to https://sbw-media.ch
- Opens in a new tab with `rel="noopener"` for security

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)