### PR TITLE
Add footer with copyright, GitHub link and release version

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@ body { font-family: 'Segoe UI', sans-serif; background: #1e1e2e; color: #cdd6f4;
 .hint { font-size: 11px; color: #6c7086; margin-left: 8px; }
 
 #canvas-wrapper { flex: 1; position: relative; overflow: hidden; cursor: grab; }
+#footer { display: flex; align-items: center; justify-content: center; gap: 16px; padding: 5px 16px; background: #181825; border-top: 1px solid #313244; font-size: 11px; color: #6c7086; flex-shrink: 0; }
+#footer a { color: #6c7086; text-decoration: none; }
+#footer a:hover { color: #cdd6f4; }
 #canvas-wrapper.panning { cursor: grabbing; }
 #canvas-wrapper.relating { cursor: crosshair; }
 #canvas { position: absolute; width: 6000px; height: 6000px; }
@@ -1126,5 +1129,12 @@ document.addEventListener('keydown', e => {
   render();
 })();
 </script>
+<div id="footer">
+  <span>Copyright, SBW Neue Medien, 2026</span>
+  <span>&middot;</span>
+  <a href="https://github.com/kingma-sbw/erm-editor" target="_blank" rel="noopener">GitHub</a>
+  <span>&middot;</span>
+  <span>v1.2.0</span>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds a slim footer bar at the bottom of the viewport
- Copyright notice: Copyright, SBW Neue Medien, 2026
- Link to the GitHub repository
- Current release version (v1.2.0)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)